### PR TITLE
Fix overview image on index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: Home
 order: 5
 ---
 
-![Terminology- and Ontology-based Phenotyping (TOP) Framework Overview: TOP enables phenotypic queries on patient or study database and ontology-based document search for medical documents.](public/top-framework-overview.svg)
+<img src="public/top-framework-overview.svg" alt="Terminology- and Ontology-based Phenotyping (TOP) Framework Overview: TOP enables phenotypic queries on patient or study database and ontology-based document search for medical documents."/>
 
 [Deutsche Version unten.](#nachwuchsgruppe-top)
 


### PR DESCRIPTION
There are more instances of broken images. e.g. the ones on the corporate design page. Maybe `![...](./public/...)` will work too.